### PR TITLE
merger: configurable one-block-files prune distance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ If you were at `firehose-core` version `1.0.0` and are bumping to `1.1.0`, you s
 
 ## v1.15.0
 
+### Added
+
+- merger: new `--merger-prune-one-block-files-after` flag (default `100`) controlling how many blocks below the last merged block one-block files are kept before deletion. Raise it so a relayer/firehose that briefly falls behind can still find the one-block files needed to bridge the gap and relink, instead of getting stuck in a reconnect loop or dying with `cannot link block after reconnection, restart required`. Clamped to a minimum of `100` (the bundle size) to preserve the safety margin against deleting not-yet-merged files.
+
 ### Changed
 
 - Bumped to [substreams@v1.19.0](https://github.com/streamingfast/substreams/releases/tag/v1.19.0)

--- a/cmd/apps/merger.go
+++ b/cmd/apps/merger.go
@@ -21,6 +21,7 @@ func RegisterMergerApp(rootLog *zap.Logger) {
 			cmd.Flags().String("merger-grpc-listen-addr", firecore.MergerServingAddr, "Address to listen for incoming gRPC requests")
 			cmd.Flags().String("merger-http-healthz-addr", firecore.MergerHTTPHealthzAddr, "Address to listen on for the HTTP /healthz endpoint. Set to an empty string to disable. Returns 200 when ready, 503 otherwise.")
 			cmd.Flags().Uint64("merger-prune-forked-blocks-after", 50000, "Number of blocks that must pass before we delete old forks (one-block-files lingering)")
+			cmd.Flags().Uint64("merger-prune-one-block-files-after", 100, "Number of blocks below the last merged block after which we delete merged one-block-files. Increase so a relayer/firehose that fell behind can still bridge the gap and relink (clamped to 100 minimum)")
 			cmd.Flags().Uint64("merger-stop-block", 0, "If non-zero, merger will trigger shutdown when blocks have been merged up to this block")
 			cmd.Flags().Duration("merger-time-between-store-lookups", 1*time.Second, "Delay between source store polling (should be higher for remote storage)")
 			cmd.Flags().Duration("merger-time-between-store-pruning", time.Minute, "Delay between source store pruning loops")
@@ -38,6 +39,7 @@ func RegisterMergerApp(rootLog *zap.Logger) {
 				GRPCListenAddr:               viper.GetString("merger-grpc-listen-addr"),
 				HTTPHealthzListenAddr:        viper.GetString("merger-http-healthz-addr"),
 				PruneForkedBlocksAfter:       viper.GetUint64("merger-prune-forked-blocks-after"),
+				PruneOneBlockFilesAfter:      viper.GetUint64("merger-prune-one-block-files-after"),
 				StorageOneBlockFilesPath:     oneBlocksStoreURL,
 				StorageMergedBlocksFilesPath: mergedBlocksStoreURL,
 				StorageForkedBlocksFilesPath: forkedBlocksStoreURL,

--- a/merger/app/merger/app.go
+++ b/merger/app/merger/app.go
@@ -44,6 +44,8 @@ type Config struct {
 
 	PruneForkedBlocksAfter uint64
 
+	PruneOneBlockFilesAfter uint64
+
 	TimeBetweenPruning time.Duration
 	TimeBetweenPolling time.Duration
 	StopBlock          uint64
@@ -107,6 +109,7 @@ func (a *App) Run() error {
 		bstream.GetProtocolFirstStreamableBlock,
 		bundleSize,
 		a.config.PruneForkedBlocksAfter,
+		a.config.PruneOneBlockFilesAfter,
 		a.config.TimeBetweenPruning,
 		a.config.TimeBetweenPolling,
 		a.config.StopBlock,

--- a/merger/healthz_test.go
+++ b/merger/healthz_test.go
@@ -18,6 +18,7 @@ func TestHealthz_Check(t *testing.T) {
 		1,
 		100,
 		100,
+		100,
 		time.Second,
 		time.Second,
 		0,

--- a/merger/merger.go
+++ b/merger/merger.go
@@ -35,8 +35,9 @@ type Merger struct {
 
 	timeBetweenPolling time.Duration
 
-	timeBetweenPruning   time.Duration
-	pruningDistanceToLIB uint64
+	timeBetweenPruning         time.Duration
+	pruningDistanceToLIB       uint64
+	oneBlockFilesPruneDistance uint64
 
 	bundler *Bundler
 }
@@ -49,20 +50,33 @@ func NewMerger(
 	firstStreamableBlock uint64,
 	bundleSize uint64,
 	pruningDistanceToLIB uint64,
+	oneBlockFilesPruneDistance uint64,
 	timeBetweenPruning time.Duration,
 	timeBetweenPolling time.Duration,
 	stopBlock uint64,
 	maxMergingThreads int,
 ) *Merger {
+	// floor at bundleSize so we never delete not-yet-merged one-block files
+	if oneBlockFilesPruneDistance < bundleSize {
+		if oneBlockFilesPruneDistance != 0 {
+			logger.Warn("one-block-files prune distance is below the bundle size, raising it to the bundle size",
+				zap.Uint64("requested", oneBlockFilesPruneDistance),
+				zap.Uint64("bundle_size", bundleSize),
+			)
+		}
+		oneBlockFilesPruneDistance = bundleSize
+	}
+
 	m := &Merger{
-		Shutter:              shutter.New(),
-		grpcListenAddr:       grpcListenAddr,
-		io:                   io,
-		firstStreamableBlock: firstStreamableBlock,
-		pruningDistanceToLIB: pruningDistanceToLIB,
-		timeBetweenPolling:   timeBetweenPolling,
-		timeBetweenPruning:   timeBetweenPruning,
-		logger:               logger,
+		Shutter:                    shutter.New(),
+		grpcListenAddr:             grpcListenAddr,
+		io:                         io,
+		firstStreamableBlock:       firstStreamableBlock,
+		pruningDistanceToLIB:       pruningDistanceToLIB,
+		oneBlockFilesPruneDistance: oneBlockFilesPruneDistance,
+		timeBetweenPolling:         timeBetweenPolling,
+		timeBetweenPruning:         timeBetweenPruning,
+		logger:                     logger,
 	}
 
 	m.bundler = NewBundler(firstStreamableBlock, stopBlock, firstStreamableBlock, bundleSize, io, maxMergingThreads, m.Shutdown)
@@ -115,7 +129,7 @@ func (m *Merger) startForkedBlocksPruner() {
 
 func (m *Merger) startOldFilesPruner() {
 	m.logger.Info("starting pruning of unused (old) one-block-files",
-		zap.Uint64("pruning_distance_to_lib", m.bundler.bundleSize),
+		zap.Uint64("pruning_distance_to_lib", m.oneBlockFilesPruneDistance),
 		zap.Duration("time_between_pruning", m.timeBetweenPruning),
 	)
 	go func() {
@@ -132,7 +146,7 @@ func (m *Merger) startOldFilesPruner() {
 
 			var toDelete []*bstream.OneBlockFile
 
-			pruningTarget := m.pruningTarget(m.bundler.bundleSize)
+			pruningTarget := m.pruningTarget(m.oneBlockFilesPruneDistance)
 			if pruningTarget == 0 {
 				m.logger.Debug("skipping file deletion until we have a pruning target")
 				continue


### PR DESCRIPTION
## Problem

The merger's old-files pruner hardcoded the prune distance to the bundle size (`100`), so merged one-block files were deleted ~100 blocks behind the merge frontier:

```go
// merger/merger.go (startOldFilesPruner)
pruningTarget := m.pruningTarget(m.bundler.bundleSize) // frontier - 100
```

A relayer/firehose whose in-memory forkable hub briefly falls behind by **more than** that distance can no longer find the one-block files it needs to bridge the gap and relink (the hub reads one-block files only — it has no merged-store fallback). The result is a reconnect loop on `… from block store: … not found`, eventually escalating to a fatal:

```
cannot link block after reconnection, restart required
```

Restarting doesn't help because every fresh bootstrap re-enters the same unlinkable state. The only manual recovery is stopping the merger long enough for the relayer to catch back up to the live edge.

## Change

Add `--merger-prune-one-block-files-after` (default `100`), mirroring the existing `--merger-prune-forked-blocks-after`. It controls how many blocks below the last merged block one-block files are retained before deletion. Raising it (e.g. `5000`–`10000`) keeps a larger window of recent one-block files so a briefly-lagging consumer can recover on its own.

- New flag → `Config.PruneOneBlockFilesAfter` → `NewMerger`, used by `startOldFilesPruner` (both the startup log and `pruningTarget`).
- The **forked**-blocks pruner is untouched (still uses `PruneForkedBlocksAfter`).
- Clamped to a minimum of the bundle size (`100`) in the constructor, with a warning if a lower non-zero value is requested.

## Safety

Raising the distance only ever makes the pruner **more conservative** — it deletes *fewer/older* one-block files and can never delete not-yet-merged files (the pruning target is computed off `getSafeBaseBlockNum()`, and the clamp preserves the existing margin). Default behavior is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)